### PR TITLE
Introduce CONFIG.maxRows for export

### DIFF
--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -1,3 +1,10 @@
+// Configuration object to customize export behavior.
+// Set `maxRows` to limit the number of rows exported.
+// Leave as `null` to export all rows.
+const CONFIG = {
+  maxRows: null,
+}
+
 function highlightDuplicatesDistinctColors() {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet()
 
@@ -69,9 +76,12 @@ function exportTdsSelectSnSheetAsExcel() {
   const tempSheet = tempSpreadsheet.getSheets()[0]
   const targetSheet = tempSheet.setName("2 - TDS SELECT SNs")
 
-  const MAX_ROWS = 50
   const numCols = sourceSheet.getLastColumn()
-  const numRows = Math.min(sourceSheet.getLastRow(), MAX_ROWS)
+  const maxRows =
+    typeof CONFIG.maxRows === 'number'
+      ? CONFIG.maxRows
+      : sourceSheet.getLastRow()
+  const numRows = Math.min(sourceSheet.getLastRow(), maxRows)
 
   const sourceRange = sourceSheet.getRange(1, 1, numRows, numCols)
 
@@ -117,7 +127,7 @@ function exportTdsSelectSnSheetAsExcel() {
     const col = range.getColumn()
     const rows = range.getNumRows()
     const cols = range.getNumColumns()
-    if (row + rows - 1 <= MAX_ROWS) {
+    if (row + rows - 1 <= maxRows) {
       targetSheet.getRange(row, col, rows, cols).merge()
     }
   })


### PR DESCRIPTION
## Summary
- allow administrators to configure a `maxRows` value for export
- update `exportTdsSelectSnSheetAsExcel` to use this limit

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `npx prettier -w "USABrasil/DEP/DEP Automation Script.js"`
- `npx eslint "USABrasil/DEP/DEP Automation Script.js"` *(fails: ESLint couldn't find a config file)*
- `npx stylelint "USABrasil/DEP/DEP Automation Script.js"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68783fa27924832987d2e36eea3fcbbe