### PR TITLE
Add basic linting configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "browser": true,
+    "es2020": true
+  },
+  "extends": ["eslint:recommended", "plugin:flowtype/recommended", "prettier"],
+  "plugins": ["flowtype"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# MySCripts
+
+This repository contains automation scripts.
+
+## Development
+
+Install dependencies:
+
+```sh
+npm install
+```
+
+Run ESLint:
+
+```sh
+npx eslint .
+```
+
+Format code with Prettier:
+
+```sh
+npx prettier --write .
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "myscripts",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-plugin-flowtype": "^8.0.3",
+    "prettier": "^3.2.5"
+  }
+}


### PR DESCRIPTION
## Summary
- set up eslint and prettier with Flow support
- provide basic config files and README instructions

## Testing
- `npm install --no-progress` *(fails: 403 Forbidden)*
- `npx eslint .` *(fails: missing eslint.config.js)*
- `npx prettier --check .`

------
https://chatgpt.com/codex/tasks/task_e_68783fb44abc8329ae527f48b3631a82