### PR TITLE
Fix docs annotations

### DIFF
--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -18,6 +18,8 @@ const CONFIG = {
 /**
  * Highlights duplicate values in column C with distinct colors.
  * Expects the active sheet to be "DEP Data".
+ *
+ * @returns {void}
  */
 function highlightDuplicatesDistinctColors() {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
@@ -81,6 +83,8 @@ function highlightDuplicatesDistinctColors() {
  * Exports the "2 - TDS SELECT SNs" sheet as a temporary Excel file.
  * Respects CONFIG.maxRows when limiting rows.
  * Opens a sidebar with download and delete links.
+ *
+ * @returns {void}
  */
 function exportTdsSelectSnSheetAsExcel() {
   const ss = SpreadsheetApp.getActiveSpreadsheet();


### PR DESCRIPTION
## Summary
- add JSDoc return type annotations for DEP script

## Testing
- `npx prettier -w "USABrasil/DEP/DEP Automation Script.js"`
- `npx eslint USABrasil/DEP/DEP\ Automation\ Script.js`

------
https://chatgpt.com/codex/tasks/task_e_68784a6c772483298bc71f0c8de5a792