### PR TITLE
Improve duplicate detection

### DIFF
--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -61,19 +61,30 @@ function highlightDuplicatesDistinctColors() {
 
   let colorIndex = 0;
 
-  const duplicates = values.filter(
-    (item, index) => values.indexOf(item) !== index && item !== "",
-  );
+  // Build frequency map to identify duplicates without costly indexOf calls.
+  const frequencyMap = new Map();
+  values.forEach((value) => {
+    if (value === "") {
+      return;
+    }
+    frequencyMap.set(value, (frequencyMap.get(value) || 0) + 1);
+  });
+
+  const duplicates = Array.from(frequencyMap.entries())
+    .filter(([, count]) => count > 1)
+    .map(([value]) => value);
+
+  const duplicateSet = new Set(duplicates);
 
   duplicates.forEach((value) => {
-    if (!(value in colorMap)) {
+    if (!Object.prototype.hasOwnProperty.call(colorMap, value)) {
       colorMap[value] = colors[colorIndex % colors.length];
       colorIndex++;
     }
   });
 
   const backgrounds = values.map((value) =>
-    duplicates.includes(value) ? [colorMap[value]] : [null],
+    duplicateSet.has(value) ? [colorMap[value]] : [null],
   );
 
   range.setBackgrounds(backgrounds);


### PR DESCRIPTION
## Summary
- optimize duplicate detection using a frequency map

## Testing
- `npx prettier --write "USABrasil/DEP/DEP Automation Script.js"`
- `npx eslint "USABrasil/DEP/DEP Automation Script.js"`

------
https://chatgpt.com/codex/tasks/task_e_68787e10f4d48329811b4b2c25024675