### PR TITLE
Fix formula removal after sheet copy

### DIFF
--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -94,6 +94,7 @@ function highlightDuplicatesDistinctColors() {
  * Exports the "2 - TDS SELECT SNs" sheet as a temporary Excel file.
  * Respects CONFIG.maxRows when limiting rows.
  * Opens a sidebar with download and delete links.
+ * Formulas in the copied sheet are replaced with static values.
  *
  * @returns {void}
  */
@@ -124,6 +125,8 @@ function exportTdsSelectSnSheetAsExcel() {
   const targetSheet = sourceSheet
     .copyTo(tempSpreadsheet)
     .setName("2 - TDS SELECT SNs");
+  const range = targetSheet.getDataRange();
+  range.copyTo(range, { contentsOnly: true });
   tempSpreadsheet.deleteSheet(defaultSheet);
 
   if (typeof CONFIG.maxRows === "number") {


### PR DESCRIPTION
## Summary
- remove formulas after copying sheet during export
- clarify behaviour in documentation block

## Testing
- `npx prettier USABrasil/DEP/'DEP Automation Script.js' --check`
- `npx eslint USABrasil/DEP/'DEP Automation Script.js'`


------
https://chatgpt.com/codex/tasks/task_e_687894cea5b883299f053ffcb0ec8db2