### PR TITLE
Fix missing DEP column check

### DIFF
--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -276,6 +276,12 @@ function createDepEmailDraft() {
   const required = ["Order ID", "Machine configuration", "SN", "ABM ID"];
   const indexes = required.map((name) => indexMap[name]);
 
+  const missing = required.filter((_, idx) => indexes[idx] === undefined);
+  if (missing.length > 0) {
+    SpreadsheetApp.getUi().alert(`Missing columns: ${missing.join(", ")}`);
+    return false;
+  }
+
   const lines = rows
     .filter((r) => r[indexes[2]])
     .map((r) => indexes.map((idx) => r[idx]).join(" | "));


### PR DESCRIPTION
## Summary
- validate required columns in `createDepEmailDraft` and alert when missing

## Testing
- `npx eslint USABrasil/DEP/DEP Automation Script.js`
- `npx prettier -w USABrasil/DEP/DEP Automation Script.js`

------
https://chatgpt.com/codex/tasks/task_e_687894d09024832993583e336ede3f3b