### PR TITLE
Fix export to capture values before copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository stores a Google Apps Script project used to automate operations 
 1. Ensure the spreadsheet contains a sheet named `2 - TDS SELECT SNs`.
 2. From the spreadsheet, run the `exportTdsSelectSnSheetAsExcel` function via **Extensions → Apps Script → Run** or create a custom menu item.
 3. After execution, a sidebar appears with links to download the temporary Excel file and delete it once finished.
+4. Formulas in the exported sheet are replaced with their evaluated values to avoid `#REF!` errors.
 
 ### `highlightDuplicatesDistinctColors`
 

--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -122,11 +122,21 @@ function exportTdsSelectSnSheetAsExcel() {
   }
 
   const defaultSheet = tempSpreadsheet.getSheets()[0];
+  const dataRange = sourceSheet.getDataRange();
+  const dataValues = dataRange.getValues();
+
   const targetSheet = sourceSheet
     .copyTo(tempSpreadsheet)
     .setName("2 - TDS SELECT SNs");
-  const range = targetSheet.getDataRange();
-  range.copyTo(range, { contentsOnly: true });
+
+  const targetRange = targetSheet.getRange(
+    dataRange.getRow(),
+    dataRange.getColumn(),
+    dataRange.getNumRows(),
+    dataRange.getNumColumns(),
+  );
+  targetRange.setValues(dataValues);
+
   tempSpreadsheet.deleteSheet(defaultSheet);
 
   if (typeof CONFIG.maxRows === "number") {


### PR DESCRIPTION
## Summary
- ensure formulas do not break during export by copying evaluated values to the new sheet
- document that formulas are replaced in the exported file

## Testing
- `npm ls --depth=0`
- `npx eslint "**/*.js"` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_687898aceb948329a2f92e571fcdd8d6