### PR TITLE
Fix DEP email header detection

### DIFF
--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -262,8 +262,9 @@ function deleteTempFile(fileId) {
 /**
  * Create a Gmail draft listing DEP device details.
  *
- * Reads the "DEP Data" sheet and compiles a table of devices
- * using Order ID, Machine configuration, SN, and ABM ID columns.
+ * Reads the "DEP Data" sheet and compiles a table of devices using
+ * Order ID, Machine configuration, SN, and ABM ID columns.
+ * The ABM ID column can also be labeled as "DEP ID" in the sheet.
  *
  * @returns {boolean} True on success, false otherwise.
  */
@@ -291,8 +292,9 @@ function createDepEmailDraft() {
 
   const required = ["order id", "machine configuration", "sn", "abm id"];
   const synonyms = {
-    sn: ["serial number"],
-    "machine configuration": ["machine configuration"],
+    sn: ["serial number", "sn"],
+    "machine configuration": ["machine configuration", "machine config"],
+    "abm id": ["dep id"],
   };
 
   const indexes = required.map((name) => {


### PR DESCRIPTION
## Summary
- allow `DEP ID` column to satisfy `ABM ID` requirement when creating the DEP email
- clarify docstring for `createDepEmailDraft`

## Testing
- `npx prettier -w USABrasil/DEP/'DEP Automation Script.js'`
- `npx eslint USABrasil/DEP/'DEP Automation Script.js'` *(fails: npm 403 Forbidden)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68789d62985c8329bebe67bf560cb5f3