### PR TITLE
Specify Gmail sender address

### DIFF
--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -371,7 +371,10 @@ function createDepEmailDraft(fileId) {
     "abrahamg@adorama.com,mendelnigri@gmail.com",
     "Expercom - Request to add to ABM",
     body,
-    { attachments: [DriveApp.getFileById(fileId)] },
+    {
+      from: "dimaiscorp@gmail.com",
+      attachments: [DriveApp.getFileById(fileId)],
+    },
   );
 
   return true;


### PR DESCRIPTION
## Summary
- specify sender when creating the Gmail draft

## Testing
- `npx prettier -c USABrasil/DEP/DEP Automation Script.js`
- `npx eslint USABrasil/DEP/DEP Automation Script.js` *(fails: Could not download eslint)*
- `npx stylelint "**/*.css"` *(fails: Could not download stylelint)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878ab1eebd483299ce9e8f684b4e942