### PR TITLE
Attach XLSX export in DEP email drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repository stores a Google Apps Script project used to automate operations 
 1. Ensure the spreadsheet contains a sheet named `DEP Data`.
 2. Run `highlightDuplicatesDistinctColors` to open the sidebar.
 3. In the sidebar, click **Create DEP Email**. This action creates a Gmail draft
-   from `dimaiscorp@gmail.com` with the exported Excel file automatically
+   from `dimaiscorp@gmail.com` with the exported spreadsheet (.xlsx) automatically
    attached.
 4. Open Gmail to review and send the draft when ready.
 


### PR DESCRIPTION
## Summary
- fetch the exported spreadsheet as XLSX when creating the DEP email draft
- clean up the temp file after attaching
- update README instructions about the attachment

## Testing
- `npx eslint "USABrasil/DEP/DEP Automation Script.js"`
- `npx flow version` *(fails: 403 Forbidden)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878ad7a3fe483299987f6478b0ac7e1