### PR TITLE
Fix highlight duplicates colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository stores a Google Apps Script project used to automate operations 
 ### `highlightDuplicatesDistinctColors`
 
 1. Activate the `DEP Data` sheet in the spreadsheet.
-2. Run the `highlightDuplicatesDistinctColors` function to color all duplicate values in column C using distinct colors.
+2. Run the `highlightDuplicatesDistinctColors` function to color all duplicate values in column C (starting at row 2) using distinct colors. The check is case-insensitive and ignores extra whitespace.
 
 ### `createDepEmailDraft`
 

--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -29,8 +29,14 @@ function highlightDuplicatesDistinctColors() {
     return;
   }
 
-  const range = sheet.getRange("C3:C" + sheet.getLastRow());
-  const values = range.getValues().flat();
+  const startRow = 2; // Skip header row
+  const range = sheet.getRange(startRow, 3, sheet.getLastRow() - startRow + 1, 1);
+  if (range.getNumRows() === 0) {
+    return;
+  }
+
+  const rawValues = range.getDisplayValues();
+  const values = rawValues.map((row) => row[0].toString().trim().toLowerCase());
 
   // Reset background color
   range.setBackground(null);
@@ -73,6 +79,10 @@ function highlightDuplicatesDistinctColors() {
   const duplicates = Array.from(frequencyMap.entries())
     .filter(([, count]) => count > 1)
     .map(([value]) => value);
+
+  if (duplicates.length === 0) {
+    return;
+  }
 
   const duplicateSet = new Set(duplicates);
 


### PR DESCRIPTION
## Summary
- update highlightDuplicatesDistinctColors to properly check column C starting from row 2
- improve duplicate detection (trim and lowercase)
- document duplicate highlighting nuances

## Testing
- `node --check 'USABrasil/DEP/DEP Automation Script.js'`
- `npx eslint 'USABrasil/DEP/DEP Automation Script.js'` *(fails: npm unable to reach network)*

------
https://chatgpt.com/codex/tasks/task_e_6878af82058883299845d4a212549f40