### PR TITLE
Add automatic draft opening after creating DEP email

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This repository stores a Google Apps Script project used to automate operations 
 3. In the sidebar, click **Create DEP Email**. This action creates a Gmail draft
    from `dimaiscorp@gmail.com` with the exported spreadsheet (.xlsx) automatically
    attached.
-4. Open Gmail to review and send the draft when ready.
+4. Once the draft is created, a new Gmail tab opens displaying your drafts so you
+   can review and send the email.
 
 ## Expected Exported File
 

--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -30,7 +30,12 @@ function highlightDuplicatesDistinctColors() {
   }
 
   const startRow = 2; // Skip header row
-  const range = sheet.getRange(startRow, 3, sheet.getLastRow() - startRow + 1, 1);
+  const range = sheet.getRange(
+    startRow,
+    3,
+    sheet.getLastRow() - startRow + 1,
+    1,
+  );
   if (range.getNumRows() === 0) {
     return;
   }
@@ -227,6 +232,10 @@ function exportTdsSelectSnSheetAsExcel() {
             .withSuccessHandler(function (result) {
               if (result === true) {
                 alert("📧 DEP email draft created.");
+                window.open(
+                  "https://mail.google.com/mail/u/0/#drafts",
+                  "_blank",
+                );
               } else {
                 alert("⚠️ Error creating email draft.");
               }


### PR DESCRIPTION
## Summary
- open the Gmail drafts page when the DEP email draft is successfully created
- document the new automatic opening behavior in README

## Testing
- `prettier -w 'USABrasil/DEP/DEP Automation Script.js'`
- `eslint 'USABrasil/DEP/DEP Automation Script.js'`
- `prettier -w README.md`


------
https://chatgpt.com/codex/tasks/task_e_6878b16ae9508329a5e2b45c30fffea3