### PR TITLE
Fix duplicate highlighting when DEP data is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository stores a Google Apps Script project used to automate operations 
 ### `highlightDuplicatesDistinctColors`
 
 1. Activate the `DEP Data` sheet in the spreadsheet.
-2. Run the `highlightDuplicatesDistinctColors` function to color all duplicate values in column C (starting at row 2) using distinct colors. The check is case-insensitive and ignores extra whitespace.
+2. Run the `highlightDuplicatesDistinctColors` function to color all duplicate values in column C starting at row 2. The check now relies on the raw cell values to avoid formatting issues and gracefully exits when no data rows are present. All matches are case-insensitive and ignore extra whitespace.
 
 ### `createDepEmailDraft`
 

--- a/USABrasil/DEP/DEP Automation Script.js
+++ b/USABrasil/DEP/DEP Automation Script.js
@@ -30,17 +30,14 @@ function highlightDuplicatesDistinctColors() {
   }
 
   const startRow = 2; // Skip header row
-  const range = sheet.getRange(
-    startRow,
-    3,
-    sheet.getLastRow() - startRow + 1,
-    1,
-  );
-  if (range.getNumRows() === 0) {
+  const lastRow = sheet.getLastRow();
+  const numRows = Math.max(lastRow - startRow + 1, 0);
+  if (numRows === 0) {
     return;
   }
 
-  const rawValues = range.getDisplayValues();
+  const range = sheet.getRange(startRow, 3, numRows, 1);
+  const rawValues = range.getValues();
   const values = rawValues.map((row) => row[0].toString().trim().toLowerCase());
 
   // Reset background color


### PR DESCRIPTION
## Summary
- avoid invalid range when no rows are present
- base duplicate detection on raw values
- clarify highlight instructions in README

## Testing
- `npm test --silent` *(fails: no test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6878b405842c8329883430a14d91f132